### PR TITLE
Fixed build issue. Renamed pckConfig to libgit2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
 	targets: [
 		.systemLibrary(
 			name: "Clibgit2",
-			pkgConfig: "git2",
+			pkgConfig: "libgit2",
 			providers: [
 				.brew(["libgit2"]),
 				.apt(["libgit2-dev"]),

--- a/Sources/SwiftGit2/Diffs.swift
+++ b/Sources/SwiftGit2/Diffs.swift
@@ -50,7 +50,7 @@ public struct Diff {
 	public struct File {
 		public var oid: OID
 		public var path: String
-		public var size: Int64
+		public var size: UInt64
 		public var flags: Flags
 
 		public init(_ diffFile: git_diff_file) {


### PR DESCRIPTION
Fixed an issue where `git2.h` is not found. I've explained the issue and the solution in this https://github.com/SwiftGit2/SwiftGit2/pull/187#issuecomment-785033172 on your original PR.